### PR TITLE
Not assuming StatusBar's height to be 0 for modal VCs

### DIFF
--- a/TLYShyNavBar/ShyControllers/TLYShyStatusBarController.m
+++ b/TLYShyNavBar/ShyControllers/TLYShyStatusBarController.m
@@ -18,12 +18,6 @@ static inline CGFloat AACStatusBarHeight(UIViewController *viewController)
     {
         return 0.f;
     }
-    
-    // Modal views do not overlap the status bar, so no allowance need be made for it
-    if (viewController.presentingViewController != nil)
-    {
-        return 0.f;
-    }
 
     CGSize  statusBarSize = [UIApplication sharedApplication].statusBarFrame.size;
     CGFloat statusBarHeight = MIN(statusBarSize.width, statusBarSize.height);


### PR DESCRIPTION
When calculating the status-bar height, the `TLYShyStatusBarController` assumes a height of 0 when the view-controller is being presented modally. This makes the NavBar disregard the StatusBar offset, and creating a large (mostly) persistent gap between the NavigationBar and content-view.

This *seems* to be the old behavior of modally presented ViewControllers _(https://www.youtube.com/watch?v=z0WsKckKnKU&t=2m24s)_, but I may be mistaken.

# Show me

|   Before |  After |
|---------|-------|
|![navbar-iphoneX-before](https://user-images.githubusercontent.com/919713/55316538-ec5a7e00-546e-11e9-8f69-185643e42f3c.gif)|![navbar-iphoneX-after](https://user-images.githubusercontent.com/919713/55316559-f67c7c80-546e-11e9-979b-739c51a450c6.gif)|
|![navbar-iphone7-before](https://user-images.githubusercontent.com/919713/55316580-01371180-546f-11e9-91e9-c2d4e1b24308.gif)|![navbar-iphone7-after](https://user-images.githubusercontent.com/919713/55316582-04ca9880-546f-11e9-9a18-e87cb4bfae5f.gif)|
|![navbar-ipad-before](https://user-images.githubusercontent.com/919713/55316603-101dc400-546f-11e9-8137-a409160a645c.gif)|![navbar-ipad-after](https://user-images.githubusercontent.com/919713/55316611-12801e00-546f-11e9-8364-07968b4eaaaf.gif)|